### PR TITLE
Minor grammar and typo improvements

### DIFF
--- a/core/annex_bibliography.adoc
+++ b/core/annex_bibliography.adoc
@@ -6,7 +6,6 @@
 * [[fielding2000]] Fielding, Roy Thomas: *Architectural Styles and the Design of Network-based Software Architectures*. Doctoral dissertation, University of California, Irvine, 2000, https://www.ics.uci.edu/~fielding/pubs/dissertation/fielding_dissertation.pdf[https://www.ics.uci.edu/fielding/pubs/dissertation/fielding_dissertation.pdf]
 * [[k-and-r-1978]] Kernighan, B., Richie, D.: *The C Programming Language*, Bell Laboratories, 1978 
 * [[link-relations]] IANA: **Link Relation Types**, https://www.iana.org/assignments/link-relations/link-relations.xml
-* [[rfc6570]] Greforio, J., Fielding, R., Hadley, M., Nottingham, M., Orchard, D.: *IETF RFC 6570, URI Template*, https://tools.ietf.org/html/rfc6570[https://tools.ietf.org/html/rfc6570]
 * [[rfc7230]] Fielding, R., Reschke, J.: **IETF RFC 7230, Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing**, https://tools.ietf.org/rfc/rfc7230.txt[https://tools.ietf.org/rfc/rfc7230.txt]
 * [[rfc7235]] Fielding, R., Reschke, J.: **IETF RFC 7235, Hypertext Transfer Protocol (HTTP/1.1): Authentication**, https://tools.ietf.org/rfc/rfc7235.txt[https://tools.ietf.org/rfc/rfc7235.txt]
 * [[rfc7538]] Reschke, J.: **IETF RFC 7538, The Hypertext Transfer Protocol Status Code 308 (Permanent Redirect)**, https://tools.ietf.org/rfc/rfc7538.txt[https://tools.ietf.org/rfc/rfc7538.txt]

--- a/core/clause_3_conformance.adoc
+++ b/core/clause_3_conformance.adoc
@@ -26,7 +26,7 @@ The OGC API - Common Standard does not mandate a specific encoding or format for
 * <<rc_html-section,HTML>>
 * <<rc_json-section,JSON>>
 
-Neither of these encodings is mandatory. An implementer of the _API-Common_ standard may decide to implement another encodings instead of, or in addition to, these two.
+Neither of these encodings is mandatory. An implementer of the _API-Common_ standard may decide to implement other encodings instead of, or in addition to, these two.
 
 The Encoding Requirements Classes are specified in <<rc_encoding-section,(Chapter 10)>> *Encoding Requirements Classes*.
 

--- a/core/clause_4_references.adoc
+++ b/core/clause_4_references.adoc
@@ -3,6 +3,7 @@ The following normative documents contain provisions that, through reference in 
 
 * [[rfc2818]] Rescorla, E.: **IETF RFC 2818, HTTP Over TLS**, http://tools.ietf.org/rfc/rfc2818.txt[http://tools.ietf.org/rfc/rfc2818.txt]
 * [[rfc3986]] Berners-Lee, T., Fielding, R., Masinter, L: **IETF RFC 3986, Uniform Resource Identifier (URI): Generic Syntax**, http://tools.ietf.org/rfc/rfc3986.txt[http://tools.ietf.org/rfc/rfc3986.txt]
+* [[rfc6570]] Gregorio, J., Fielding, R., Hadley, M., Nottingham, M., Orchard, D: **IETF RFC 6570, URI Template**, https://www.rfc-editor.org/rfc/rfc6570.txt[https://www.rfc-editor.org/rfc/rfc6570.txt]
 * [[rfc7231]] Fielding, R., Reschke, J.: **IETF RFC 7231, Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content**, https://tools.ietf.org/rfc/rfc7231.txt[https://tools.ietf.org/rfc/rfc7231.txt]
 * [[rfc7232]] Fielding, R., Reschke, J.: **IETF RFC 7232, Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests**, https://tools.ietf.org/rfc/rfc7232.txt[https://tools.ietf.org/rfc/rfc7232.txt]
 * [[rfc7807]] Nottingham, M., Wilde, E.: **IETF RFC 7807, Problem Details for HTTP APIs**, https://tools.ietf.org/rfc/rfc7807.txt[https://tools.ietf.org/rfc/rfc7807.txt]

--- a/core/clause_5_terms_and_definitions.adoc
+++ b/core/clause_5_terms_and_definitions.adoc
@@ -10,7 +10,7 @@ For the purposes of this document, the following additional terms and definition
 
 [[kebab-case-definition]]
 * *Kebab case* +
-A case style where punctuation is removed and spaces are replaced by single hyphens. All letters are in lower case when used in OGC documentation. (https://en.wikipedia.org/wiki/Letter_case[Wikipedia]) 
+A case style where punctuation is removed and spaces are replaced by single hyphens. All letters are in lower case when used in OGC documentation. (https://en.wikipedia.org/wiki/Letter_case[Wikipedia]) Example: `kebab-case-style`
 
 [[landing-page-definition]]
 * *Landing Page* +
@@ -80,6 +80,8 @@ OGC::
     Open Geospatial Consortium
 URI::
     Uniform Resource Identifier
+URL::
+    Uniform Resource Locator
 YAML::
     YAML Ain’t Markup Language
 

--- a/core/clause_6_conventions.adoc
+++ b/core/clause_6_conventions.adoc
@@ -86,14 +86,14 @@ OGC                {root}            path            parameters
 
 This document does not restrict the lexical space of URIs used in the API beyond the requirements of the <<rfc7231,HTTP>> and <<rfc3986,URI Syntax>> IETF RFCs. If URIs include reserved characters that are delimiters in the URI subcomponent, these have to be percent-encoded. See Clause 2 of <<rfc3986,RFC 3986>> for details.
 
-NOTE: OGC Web API standards may include a community-defined identifier as part of a URI (ex. image id or feature id). Definition of the format of those identifiers is out of scope for these standards. Implementers should take care that these identifiers are properly encoded (see <<rfc3986,RFC 3986>>) in the URIs for all hosted resources.   
+NOTE: OGC Web API standards may include a community-defined identifier as part of a URI (for example: image id or feature id). Definition of the format of those identifiers is out of scope for these standards. Implementers should take care that these identifiers are properly encoded (see <<rfc3986,RFC 3986>>) in the URIs for all hosted resources.   
 
 Additional information on this topic is provided in the link:http://docs.opengeospatial.org/DRAFTS/20-071.html#identifiers-section[OGC API - Common Users Guide]. 
 
 [[link-conventions]]
 === Links
 
-OGC Web API Standards use <<rfc8288,RFC 8288 (Web Linking)>>  to express relationships between resources. Resource representations defined in these standards commonly include an "links" element. A "links" element is an array of individual hyperlink elements. These "links" elements provide a convention for associating related resources.
+OGC Web API Standards use <<rfc8288,RFC 8288 (Web Linking)>>  to express relationships between resources. Resource representations defined in these standards commonly include a "links" element. A "links" element is an array of individual hyperlink elements. These "links" elements provide a convention for associating related resources.
 
 The individual hyperlink elements that make up a "links" element are defined using the following link:http://beta.schemas.opengis.net/ogcapi/common/part1/0.1/core/openapi/schemas/link.yaml[Hyperlink Schema].
 

--- a/core/clause_8_landing-page.adoc
+++ b/core/clause_8_landing-page.adoc
@@ -27,7 +27,7 @@ The purpose of the landing page is to provide clients with a starting point for 
 
 The landing page includes three metadata elements: title, description, and attribution. These three elements describe the API as a whole. Clients can expect to encounter metadata that is more resource-specific as they follow links and paths from the landing page. 
 
-While the three metadata elements are defined as text strings, the attribution element is special. Specifically, The attribution element can contain markup text. Markup allows a text string to import images and format text. The capabilities are only limited by the markup language used. See the example <<json-landing-page,landing page>> for an example of the use of markup in the attribution element.
+While the three metadata elements are defined as text strings, the attribution element is special. Specifically, the attribution element can contain markup text. Markup allows a text string to import images and format text. The capabilities are only limited by the markup language used. See the example <<json-landing-page,landing page>> for an example of the use of markup in the attribution element.
 
 ==== Operation
 

--- a/general/recommendations/general/REC_query-param-capitalization.adoc
+++ b/general/recommendations/general/REC_query-param-capitalization.adoc
@@ -2,6 +2,6 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/core/query-param-capitalization* 
-^|A |Query parameter names SHOULD be in <<kebab-case-definition,Kebab case>>.
+^|A |Query parameter names SHOULD be in <<kebab-case-definition,kebab case>>.
 ^|B |Query parameter values are usually reflective of the internal structure of the target resource. Unless otherwise specified, these values SHOULD be in <<kebab-case-definition,kebab case>>.
 |===


### PR DESCRIPTION
@cmheazel Main change is moving RFC6570 from Bibliography for References, as it is mentioned in Requirements.
Also, should the Definitions Annex have a definition of `Permission`?
Hopefully, my fork is not too far adrift of the Master Branch.
Couldn't find anything to criticise! Great work and much easier to read.